### PR TITLE
Make arguments not optional by default

### DIFF
--- a/src/CortexPE/Commando/args/BaseArgument.php
+++ b/src/CortexPE/Commando/args/BaseArgument.php
@@ -38,7 +38,7 @@ abstract class BaseArgument {
 	/** @var bool */
 	protected $optional = false;
 
-	public function __construct(string $name, bool $optional) {
+	public function __construct(string $name, bool $optional = false) {
 		$this->name = $name;
 		$this->optional = $optional;
 	}


### PR DESCRIPTION
This makes it easier for me, but it's just a nitpick.
The variable is false by default anyway, so why not put it in the constructor too?