### PR TITLE
phpstan $args type fix

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -2,6 +2,7 @@
 branches:
 - master
 - PM4
+- phpstan-fix
 projects:
   Commando:
     model: virion

--- a/src/CortexPE/Commando/BaseCommand.php
+++ b/src/CortexPE/Commando/BaseCommand.php
@@ -166,7 +166,7 @@ abstract class BaseCommand extends Command implements IArgumentable, IRunnable, 
 	/**
 	 * @param CommandSender  $sender
 	 * @param string         $aliasUsed
-	 * @param BaseArgument[] $args
+	 * @param array|array<string,mixed|array<mixed>> $args
 	 */
 	abstract public function onRun(CommandSender $sender, string $aliasUsed, array $args): void;
 


### PR DESCRIPTION
Currently phpstan is complaining that BaseArgument can not be parsed to string.

This PR fixes it by fixing the onRun() DocComment.

Plugins might need to use 
```php
	/**
	 * @inheritDoc
	 */
	public function onRun(CommandSender $sender, string $aliasUsed, array $args): void
```
in child classes of BaseCommand/BaseSubCommand