### PR TITLE
PacketHooker: Fix isRegistered() does not work

### DIFF
--- a/src/CortexPE/Commando/PacketHooker.php
+++ b/src/CortexPE/Commando/PacketHooker.php
@@ -63,6 +63,7 @@ class PacketHooker implements Listener {
 		if(self::$isRegistered) {
 			throw new HookAlreadyRegistered("Event listener is already registered by another plugin.");
 		}
+		self::$isRegistered = true;
 
 		$interceptor = SimplePacketHandler::createInterceptor($registrant, EventPriority::NORMAL, false);
 		$interceptor->interceptOutgoing(function(AvailableCommandsPacket $pk, NetworkSession $target) : bool{

--- a/src/CortexPE/Commando/PacketHooker.php
+++ b/src/CortexPE/Commando/PacketHooker.php
@@ -63,7 +63,6 @@ class PacketHooker implements Listener {
 		if(self::$isRegistered) {
 			throw new HookAlreadyRegistered("Event listener is already registered by another plugin.");
 		}
-		self::$isRegistered = true;
 
 		$interceptor = SimplePacketHandler::createInterceptor($registrant, EventPriority::NORMAL, false);
 		$interceptor->interceptOutgoing(function(AvailableCommandsPacket $pk, NetworkSession $target) : bool{
@@ -86,6 +85,8 @@ class PacketHooker implements Listener {
 			self::$isIntercepting = false;
 			return false;
 		});
+		
+		self::$isRegistered = true;
 	}
 
 	/**


### PR DESCRIPTION
Hi, this fixes an issue where `PacketHooker::isRegistered()` doesn't work.

Call `PacketHooker::register()`, `PacketHooker::isRegistered()` should return true. but it returns false.
And since the flag has not been updated, multiple registration is possible without exception.

```php
var_dump(PacketHooker::isRegistered());
PacketHooker::register($this);
var_dump(PacketHooker::isRegistered());
PacketHooker::register($this);
```

result:
```
bool(false)
bool(false)
```
