### PR TITLE
Protocol Updates

### DIFF
--- a/src/CortexPE/Commando/PacketHooker.php
+++ b/src/CortexPE/Commando/PacketHooker.php
@@ -40,6 +40,7 @@ use pocketmine\event\Listener;
 use pocketmine\network\mcpe\NetworkSession;
 use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
 use pocketmine\network\mcpe\protocol\types\command\CommandEnum;
+use pocketmine\network\mcpe\protocol\types\command\CommandOverload;
 use pocketmine\network\mcpe\protocol\types\command\CommandParameter;
 use pocketmine\plugin\Plugin;
 use pocketmine\Server;
@@ -90,7 +91,7 @@ class PacketHooker implements Listener {
 	 * @param CommandSender $cs
 	 * @param BaseCommand $command
 	 *
-	 * @return CommandParameter[][]
+	 * @return CommandOverload[][]
 	 */
 	private static function generateOverloads(CommandSender $cs, BaseCommand $command): array {
 		$overloads = [];
@@ -113,11 +114,10 @@ class PacketHooker implements Listener {
 			$overloadList = self::generateOverloadList($subCommand);
 			if(!empty($overloadList)){
 				foreach($overloadList as $overload) {
-					array_unshift($overload, $scParam);
-					$overloads[] = $overload;
+					$overloads[] = new CommandOverload(false, [$scParam, ...$overload->getParameters()]);
 				}
 			} else {
-				$overloads[] = [$scParam];
+				$overloads[] = new CommandOverload(false, [$scParam]);
 			}
 		}
 
@@ -131,7 +131,7 @@ class PacketHooker implements Listener {
 	/**
 	 * @param IArgumentable $argumentable
 	 *
-	 * @return CommandParameter[][]
+	 * @return CommandOverload[][]
 	 */
 	private static function generateOverloadList(IArgumentable $argumentable): array {
 		$input = $argumentable->getArgumentList();
@@ -154,7 +154,7 @@ class PacketHooker implements Listener {
 					$refProp->setValue($param->enum, "enum#" . spl_object_id($param->enum));
 				}
 			}
-			$combinations[] = $set;
+			$combinations[] = new CommandOverload(false, $set);
 
 			foreach($indexes as $k => $v){
 				$indexes[$k]++;

--- a/virion.yml
+++ b/virion.yml
@@ -1,5 +1,5 @@
 name: Commando
 antigen: CortexPE\Commando
 api: 4.0.0
-version: 3.1.0
+version: 3.2.0
 author: CortexPE


### PR DESCRIPTION
This PR makes Commando work on the latest PMMP API 4 release and closes #46. Credits to @jasonw4331 for [his update](https://github.com/Paroxity/Commando/commit/6a8397480257a139fabbc6c66178154d4f455851) on a fork that's on API 5.